### PR TITLE
Update minimum NumPy to 1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,5 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "numpy>=1.21"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    numpy>=1.21
+    numpy>=1.22
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Fix vulnerability: GHSA-fpfv-jqm9-f5jm
Which affects NumPy <= 1.21.6

