### PR TITLE
Cleanup for 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ instead of using this wrapper.
 
 ## Installation
 
-Requires `python>=3.8`, `numpy>=1.21`, and the Tektronix RSA API for Linux.
+Requires `python>=3.8`, `numpy>=1.22`, and the Tektronix RSA API for Linux.
 
 First, download and install the
 [RSA API for Linux](https://www.tek.com/spectrum-analyzer/rsa306-software/rsa-application-programming-interface--api-for-64bit-linux--v100014)

--- a/src/rsa_api/__init__.py
+++ b/src/rsa_api/__init__.py
@@ -2,5 +2,5 @@
 
 Refer to the README file for detailed usage information.
 """
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 from .rsa_api import *


### PR DESCRIPTION
- Fix incorrect NumPy version listed in README
- Increment version number

1.2.3 contains no functional changes from 1.2.2, but is being pushed as an update so that documentation is accurate and tagged to a release.