### PR TITLE
Fix status parser for direct streaming mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.1.0
     hooks:
       - id: check-ast
         types: [file, python]
@@ -16,24 +16,24 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.10.1
     hooks:
       - id: isort
         name: isort (python)
         types: [file, python]
         args: ["--profile", "black", "--filter-files", "--gitignore"]
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 22.6.0
     hooks:
       - id: black
         types: [file, python]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.31.1
     hooks:
       - id: markdownlint
         types: [file, markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: pyupgrade
         args: ["--py3-plus"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
         types: [file, python]
@@ -16,23 +16,24 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
+        args: ["--py3-plus"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         name: isort (python)
         types: [file, python]
         args: ["--profile", "black", "--filter-files", "--gitignore"]
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.12.0
     hooks:
       - id: black
         types: [file, python]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.33.0
     hooks:
       - id: markdownlint
         types: [file, markdown]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ tasks. These "helper functions" include:
 - `IQBLK_Acquire()`
 - `IQBLK_Configure()`
 - `SPECTRUM_Acquire()`
-- `IQSTREAM_StatusParser()`
+- `IQSTREAMFileInfo_StatusParser()`
+- `IQSTREAMIQInfo_StatusParser()`
 - `IQSTREAM_Tempfile()`
 - `IQSTREAM_Tempfile_NoConfig()`
 - `DEVICE_SearchAndConnect()`
@@ -109,6 +110,8 @@ Known issues exist in the underlying Tektronix RSA API for Linux, and therefore 
 wrapper is limited in certain ways. The list of known issues is provided by Tektronix in
 the [Tektronix RSA API for Linux release notes](https://download.tek.com/software/supporting_files/ReleaseNotes_1_0_0014_64bit_066207701.txt)
 (up-to-date as of version 1.0.0014).
+
+### TODO: Update this section after resolving
 
 Additionally, a known issue exists with parsing IQ streaming status data structures.
 There appears to be a discrepancy between the documented status message encoding scheme

--- a/README.md
+++ b/README.md
@@ -108,7 +108,16 @@ To read more about these functions, check their docstrings with `help()`.
 Known issues exist in the underlying Tektronix RSA API for Linux, and therefore this
 wrapper is limited in certain ways. The list of known issues is provided by Tektronix in
 the [Tektronix RSA API for Linux release notes](https://download.tek.com/software/supporting_files/ReleaseNotes_1_0_0014_64bit_066207701.txt)
-(up-to-date as of version 1.0.0014):
+(up-to-date as of version 1.0.0014).
+
+Additionally, a known issue exists with parsing IQ streaming status data structures.
+There appears to be a discrepancy between the documented status message encoding scheme
+and the implemented encoding scheme. In its current implementation, this API wrapper has
+been tested to ensure that ADC overrange events are properly flagged when using
+`IQSTREAM_Tempfile`, `IQSTREAM_Tempfile_NoConfig` or `IQSTREAM_Acquire` methods. Buffer
+overflow warnings and errors should work, but have not been tested. The USB data
+discontinuity status is unable to be parsed. Unknown IQ stream status codes are treated
+as errors and handled as configured in `IQSTREAM_StatusParser`.
 
 ## Development
 

--- a/src/rsa_api/__init__.py
+++ b/src/rsa_api/__init__.py
@@ -1,3 +1,3 @@
 from .rsa_api import *
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -2399,7 +2399,7 @@ class RSA:
             # testable status is ADC overrange: and this is shown to work
             # for both IQSTREAM_Tempfile and IQSTREAM_Acquire helper methods.
             if bool(status & 0x10000):  # mask bit 16
-                status_str += "Input overrange\n."
+                status_str += "Input overrange.\n"
             # if bool(status & 0x20000):  # mask bit 17
             # status_str += "USB data stream discontinuity.\n"
             if bool(status & 0x40000):  # mask bit 18
@@ -2413,7 +2413,7 @@ class RSA:
                 status_str += "Output buffer overflow. File writing too slow, "
                 status_str += "data loss has occurred.\n"
             if status_str == "":
-                status_str += "Unknown nonzero status code"
+                status_str += "Unknown nonzero status code\n"
             if exit:
                 # Raise error with full string if configured
                 raise RSAError(status_str)

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -2494,7 +2494,7 @@ class RSA:
             if exit:
                 # Raise error with full string if configured
                 raise RSAError(status_str)
-        return status_str
+        return f"{status_str}, {status=} (type {type(status)})"
 
     def SPECTRUM_Acquire(
         self, trace: str = "Trace1", trace_points: int = 801, timeout_msec: int = 50

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -2406,23 +2406,7 @@ class RSA:
             if bool(status & 0x200000):  # mask bit 21
                 status_str += "Output buffer overflow. File writing too slow, "
                 status_str += "data loss has occurred.\n"
-            if any(
-                [
-                    bool(status & bm)
-                    for bm in [
-                        0x400000,
-                        0x800000,
-                        0x1000000,
-                        0x2000000,
-                        0x4000000,
-                        0x8000000,
-                        0x10000000,
-                        0x20000000,
-                        0x40000000,
-                        0x80000000,
-                    ]
-                ]
-            ):
+            if bool(status & 0xFFC00000):
                 status_str += (
                     "Invalid status code returned. Some always-zero bits are nonzero."
                 )
@@ -2503,23 +2487,7 @@ class RSA:
             if bool(status & 0x200000):  # mask bit 21
                 status_str += "Output buffer overflow. File writing too slow, "
                 status_str += "data loss has occurred.\n"
-            if any(
-                [
-                    bool(status & bm)
-                    for bm in [
-                        0x400000,
-                        0x800000,
-                        0x1000000,
-                        0x2000000,
-                        0x4000000,
-                        0x8000000,
-                        0x10000000,
-                        0x20000000,
-                        0x40000000,
-                        0x80000000,
-                    ]
-                ]
-            ):
+            if bool(status & 0xFFC00000):
                 status_str += (
                     "Invalid status code returned. Some always-zero bits are nonzero."
                 )

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -133,7 +133,7 @@ class RSAError(Exception):
     def __init__(self, err_txt=""):
         self.err_txt = err_txt
         err = "RSA Error: {}".format(self.err_txt)
-        super(RSAError, self).__init__(err)
+        super().__init__(err)
 
 
 class RSA:

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -2186,7 +2186,7 @@ class RSA:
             IQ data, with each element in the form (I + j*Q)
         iq_status : str (optional)
             The status string for the IQ capture, as defined in
-            the documentation for IQSTREAM_StatusParser().
+            the documentation for IQSTREAMFileInfo_StatusParser().
         """
         # Configuration parameters
         dest = _IQS_OUT_DEST[3]  # Split SIQ format
@@ -2222,7 +2222,7 @@ class RSA:
 
             # Check acquisition status
             file_info = self.IQSTREAM_GetDiskFileInfo()
-            iq_status = self.IQSTREAM_StatusParser(file_info, not return_status)
+            iq_status = self.IQSTREAMFileInfo_StatusParser(file_info, not return_status)
 
             self.DEVICE_Stop()
 
@@ -2275,7 +2275,7 @@ class RSA:
             IQ data, with each element in the form (I + j*Q)
         iq_status : str (optional)
             The status code for the IQ capture, as defined in
-            the documentation for IQSTREAM_StatusParser().
+            the documentation for IQSTREAMFileInfo_StatusParser().
         """
         # Configuration parameters
         dest = _IQS_OUT_DEST[3]  # Split SIQ format
@@ -2314,7 +2314,7 @@ class RSA:
 
             # Check acquisition status
             file_info = self.IQSTREAM_GetDiskFileInfo()
-            iq_status = self.IQSTREAM_StatusParser(file_info, not return_status)
+            iq_status = self.IQSTREAMFileInfo_StatusParser(file_info, not return_status)
 
             self.DEVICE_Stop()
 
@@ -2335,27 +2335,26 @@ class RSA:
             return iq_data
 
     @staticmethod
-    def IQSTREAM_StatusParser(
-        iq_stream_info: Union[_IQStreamFileInfo, _IQStreamIQInfo], exit: bool = True
-    ):
+    def IQSTREAMFileInfo_StatusParser(
+        iq_stream_info: _IQStreamFileInfo, exit: bool = True
+    ) -> Union[None, str]:
         """
-        Parse _IQStreamFileInfo or _IQStreamIQInfo to get acquisition status.
+        Parse an _IQStreamFileInfo struct to get the acquisition status.
 
-        Depending on the 'exit' parameter, this method will either raise an
-        error, or return a status string. Possible values for the
-        returned status indicator are:
+        Depending on the ``exit`` parameter, this method will either raise an
+        error or return a status string. Possible values for the
+        returned status string (when ``exit`` is False):
 
-        status | Definition
-        -------------------
-           0   | No error
-           1   | Input overrange.
-           2   | USB data stream discontinuity.
-           3   | Input buffer > 75% full.
-           4   | Input buffer overflow. IQ Stream processing
-               | too slow. Data loss has occurred.
-           5   | Output buffer > 75% full.
-           6   | Output buffer overflow. File writing
-               | too slow. Data loss has occurred.
+        - No error
+        - Input overrange.
+        - USB data stream discontinuity.
+        - Input buffer > 75% full.
+        - Input buffer overflow. IQ Stream processing
+          too slow. Data loss has occurred.
+        - Output buffer > 75% full.
+        - Output buffer overflow. File writing
+          too slow. Data loss has occurred.
+        - Invalid status code returned. Some always-zero bits are nonzero.
 
         In the case of multiple status codes being returned, the status
         string will contain all returned status strings, separated by line
@@ -2366,8 +2365,10 @@ class RSA:
         iq_stream_info : _IQStreamFileInfo
             The IQ streaming status information structure.
         exit : bool
-            If True, raise an exception for any error status in the IQ stream.
-            If False, return a flag representing the error, without raising an exception.
+            If True, raise an exception for any error or warning status in the
+                IQ stream. Return None if there is no error or warning.
+            If False, return a string indicating the status, without raising
+                an exception.
 
         Returns
         -------
@@ -2377,31 +2378,24 @@ class RSA:
         Raises
         ------
         RSAError
-            If errors have occurred during IQ streaming, and exit is True.
+            If errors or warnings have occurred during IQ streaming, and
+            ``exit`` is True.
         """
         status = iq_stream_info.acqStatus
+        status_str = ""
 
         # Handle no error case
         if status == 0:
             if exit:
                 return
             else:
-                return "No error."
+                status_str += "No error."
         else:
             # Construct status string if status != 0
-            status_str = ""
-            # Note: the API programming manual gives one specification
-            # for the structuring of status bits, and the RSA_API Python
-            # example code from Tektronix gives another. The latter appears
-            # to work, however it lacks the ability to detect the "USB data
-            # stream discontinuity" status. Attempting to implement it as
-            # described in the programming manual does not work. The only
-            # testable status is ADC overrange: and this is shown to work
-            # for both IQSTREAM_Tempfile and IQSTREAM_Acquire helper methods.
             if bool(status & 0x10000):  # mask bit 16
                 status_str += "Input overrange.\n"
-            # if bool(status & 0x20000):  # mask bit 17
-            # status_str += "USB data stream discontinuity.\n"
+            if bool(status & 0x20000):  # mask bit 17
+                status_str += "USB data stream discontinuity.\n"
             if bool(status & 0x40000):  # mask bit 18
                 status_str += "Input buffer > 75{} full.\n".format("%")
             if bool(status & 0x80000):  # mask bit 19
@@ -2412,14 +2406,127 @@ class RSA:
             if bool(status & 0x200000):  # mask bit 21
                 status_str += "Output buffer overflow. File writing too slow, "
                 status_str += "data loss has occurred.\n"
-            if status_str == "":
-                status_str += "Unknown nonzero status code\n"
+            if any(
+                [
+                    bool(status & bm)
+                    for bm in [
+                        0x400000,
+                        0x800000,
+                        0x1000000,
+                        0x2000000,
+                        0x4000000,
+                        0x8000000,
+                        0x10000000,
+                        0x20000000,
+                        0x40000000,
+                        0x80000000,
+                    ]
+                ]
+            ):
+                status_str += (
+                    "Invalid status code returned. Some always-zero bits are nonzero."
+                )
             if exit:
                 # Raise error with full string if configured
                 raise RSAError(status_str)
+        return status_str
+
+    @staticmethod
+    def IQSTREAMIQInfo_StatusParser(
+        iq_stream_info: _IQStreamIQInfo, exit: bool = True
+    ) -> Union[None, str]:
+        """
+        Parse an _IQStreamIQInfo struct to get the acquisition status.
+
+        Depending on the ``exit`` parameter, this method will either raise an
+        error or return a status string. Possible values for the
+        returned status string (when ``exit`` is False):
+
+        - No error
+        - Input overrange.
+        - USB data stream discontinuity.
+        - Input buffer > 75% full.
+        - Input buffer overflow. IQ Stream processing
+          too slow. Data loss has occurred.
+        - Output buffer > 75% full.
+        - Output buffer overflow. File writing
+          too slow. Data loss has occurred.
+        - Invalid status code returned. Some always-zero bits are nonzero.
+
+        In the case of multiple status codes being returned, the status
+        string will contain all returned status strings, separated by line
+        breaks.
+
+        Parameters
+        ----------
+        iq_stream_info : _IQStreamFileInfo
+            The IQ streaming status information structure.
+        exit : bool
+            If True, raise an exception for any error or warning status in the
+                IQ stream. Return None if there is no error or warning.
+            If False, return a string indicating the status, without raising
+                an exception.
+
+        Returns
+        -------
+        status: str
+            A string containing all returned status messages.
+
+        Raises
+        ------
+        RSAError
+            If errors or warnings have occurred during IQ streaming, and
+            ``exit`` is True.
+        """
+        status = iq_stream_info.acqStatus
+        status_str = ""
+
+        # Handle no error case
+        if status == 0:
+            if exit:
+                return
             else:
-                # Or just return the status string
-                return status_str
+                status_str += "No error."
+        else:
+            # Construct status string if status != 0
+            if bool(status & 0x10000):  # mask bit 16
+                status_str += "Input overrange.\n"
+            if bool(status & 0x20000):  # mask bit 17
+                status_str += "USB data stream discontinuity.\n"
+            if bool(status & 0x40000):  # mask bit 18
+                status_str += "Input buffer > 75{} full.\n".format("%")
+            if bool(status & 0x80000):  # mask bit 19
+                status_str += "Input buffer overflow. IQStream processing too"
+                status_str += " slow, data loss has occurred.\n"
+            if bool(status & 0x100000):  # mask bit 20
+                status_str += "Output buffer > 75{} full.\n".format("%")
+            if bool(status & 0x200000):  # mask bit 21
+                status_str += "Output buffer overflow. File writing too slow, "
+                status_str += "data loss has occurred.\n"
+            if any(
+                [
+                    bool(status & bm)
+                    for bm in [
+                        0x400000,
+                        0x800000,
+                        0x1000000,
+                        0x2000000,
+                        0x4000000,
+                        0x8000000,
+                        0x10000000,
+                        0x20000000,
+                        0x40000000,
+                        0x80000000,
+                    ]
+                ]
+            ):
+                status_str += (
+                    "Invalid status code returned. Some always-zero bits are nonzero."
+                )
+            if exit:
+                # Raise error with full string if configured
+                raise RSAError(status_str)
+        return status_str
 
     def SPECTRUM_Acquire(
         self, trace: str = "Trace1", trace_points: int = 801, timeout_msec: int = 50
@@ -2572,7 +2679,7 @@ class RSA:
             IQ data, with each element in the form (I + j*Q)
         iq_status : str (optional)
             The status string for the IQ capture, as defined in
-            the documentation for IQSTREAM_StatusParser().
+            the documentation for IQSTREAMIQInfo_StatusParser().
         """
         dest = _IQS_OUT_DEST[0]  # Client
         dtype = _IQS_OUT_DTYPE[0]  # Single
@@ -2626,7 +2733,7 @@ class RSA:
         assert len(iqdata) == iq_samples_requested
 
         if return_status:
-            iq_status = self.IQSTREAM_StatusParser(iqinfo, not return_status)
+            iq_status = self.IQSTREAMIQInfo_StatusParser(iqinfo, not return_status)
             return iqdata, iq_status
         else:
             return iqdata

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -2494,7 +2494,7 @@ class RSA:
             if exit:
                 # Raise error with full string if configured
                 raise RSAError(status_str)
-        return f"{status_str}, {status=} (type {type(status)})"
+        return f"{status_str}, {status=}"
 
     def SPECTRUM_Acquire(
         self, trace: str = "Trace1", trace_points: int = 801, timeout_msec: int = 50

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -2443,7 +2443,7 @@ class RSA:
 
         Parameters
         ----------
-        iq_stream_info : _IQStreamFileInfo
+        iq_stream_info : _IQStreamIQInfo
             The IQ streaming status information structure.
         exit : bool
             If True, raise an exception for any error or warning status in the


### PR DESCRIPTION
Problem: in direct IQ streaming mode (using `IQSTREAM_Acquire`), the returned status code does not conform to the Tektronix API documentation. As of v1.3.0 of this API wrapper, this results in "No error" status being returned when ADC overrange events occur. The problem does not affect `IQSTREAM_Tempfile` methods in v1.3.0. It is provable that returned codes do not conform to the documentation since non-zero bits occur in places 6-15 and 22-31, which are unused and should always be zero according to the programming manual. It could be possible that the ctypes structure being used to retrieve these results is incorrectly configured; if this is the case, it is because neither the programming manual nor example code provided by Tektronix implement this structure correctly. Without being able to see the source code of the API, this problem remains unfixable at its core until Tektronix issues an update to the RSA API for Linux.

Solution: This PR updates the status parser so that ADC overrange events are always correctly flagged. This has been confirmed through testing with both `IQSTREAM_Acquire` and `IQSTREAM_Tempfile` methods on RSA306B and RSA507A hardware. The "USB data stream discontinuity" status flag is erroneously returned by streaming IQ direct to client, so it has been removed from the status parser. Additionally, status codes are sometimes returned which do not match any codes recorded in the documentation. A catchall status response has been added to handle these. It is recommended that applications using this API wrapper take care in their handling of return statuses. Return statuses for no error and overrange appear to always be correct, however it seems that unknown codes are sometimes returned when there is no error as well. Use of the Tempfile methods seems not to yield unknown status codes, and is a viable way to circumvent this problem

For more context see the parser example offered by Tektronix [here](https://github.com/tektronix/RSA_API/blob/712cf5c84b22b2d8095984414bffc423be06bd19/Python/rsa_api_full_example.py#L411)