### PR TITLE
Update pre-commit hooks, clean up LICENSE markdown, Python 3.12 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-ast
         types: [file, python]
@@ -16,24 +16,24 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)
         types: [file, python]
         args: ["--profile", "black", "--filter-files", "--gitignore"]
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.4.2
     hooks:
       - id: black
         types: [file, python]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.40.0
     hooks:
       - id: markdownlint
         types: [file, markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,4 +37,4 @@ repos:
     hooks:
       - id: markdownlint
         types: [file, markdown]
-        exclude: GitHubRepoPublicReleaseApproval.md|LICENSE.md
+        exclude: GitHubRepoPublicReleaseApproval.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.15.2
     hooks:
       - id: pyupgrade
-        args: ["--py3-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,13 +1,34 @@
-SOFTWARE DISCLAIMER / RELEASE
+# SOFTWARE DISCLAIMER / RELEASE
 
-This software was developed by employees of the National Telecommunications and Information Administration (NTIA), an agency of the Federal Government and is provided to you as a public service.  Pursuant to Title 15 United States Code Section 105, works of NTIA employees are not subject to copyright protection within the United States.
+This software was developed by employees of the National Telecommunications and Information
+Administration (NTIA), an agency of the Federal Government and is provided to you
+as a public service.  Pursuant to Title 15 United States Code Section 105, works
+of NTIA employees are not subject to copyright protection within the United States.
 
-The software is provided by NTIA “AS IS.”  NTIA MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED OR STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NTIA does not warrant or make any representations regarding the use of the software or the results thereof, including but not limited to the correctness, accuracy, reliability or usefulness of the software.
+The software is provided by NTIA “AS IS.”  NTIA MAKES NO WARRANTY OF ANY KIND, EXPRESS,
+IMPLIED OR STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND DATA ACCURACY. NTIA does
+not warrant or make any representations regarding the use of the software or the
+results thereof, including but not limited to the correctness, accuracy, reliability
+or usefulness of the software.
 
-To the extent that NTIA holds rights in countries other than the United States, you are hereby granted the non-exclusive irrevocable and unconditional right to print, publish, prepare derivative works and distribute the NTIA software, in any medium, or authorize others to do so on your behalf, on a royalty-free basis throughout the World.
+To the extent that NTIA holds rights in countries other than the United States,
+you are hereby granted the non-exclusive irrevocable and unconditional right to
+print, publish, prepare derivative works and distribute the NTIA software, in any
+medium, or authorize others to do so on your behalf, on a royalty-free basis throughout
+the World.
 
-You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change.
+You may improve, modify, and create derivative works of the software or any portion
+of the software, and you may copy and distribute such modifications or works. Modified
+works should carry a notice stating that you changed the software and should note
+the date and nature of any such change.
 
-You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property.
+You are solely responsible for determining the appropriateness of using and distributing
+the software and you assume all risks associated with its use, including but not
+limited to the risks and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and the unavailability or interruption
+of operation. This software is not intended to be used in any situation where a failure
+could cause risk of injury or damage to property.
 
-Please provide appropriate acknowledgments of NTIA’s creation of the software in any copies or derivative works of this software.
+Please provide appropriate acknowledgments of NTIA’s creation of the software in
+any copies or derivative works of this software.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -144,7 +144,7 @@ class _IQStreamIQInfo(Structure):  # "IQSTRMIQINFO" in RSA_API.h
 class RSAError(Exception):
     def __init__(self, err_txt=""):
         self.err_txt = err_txt
-        err = "RSA Error: {}".format(self.err_txt)
+        err = f"RSA Error: {self.err_txt}"
         super().__init__(err)
 
 

--- a/src/rsa_api/rsa_api.py
+++ b/src/rsa_api/rsa_api.py
@@ -3,6 +3,7 @@ Written for Tektronix RSA API for Linux v1.0.0014
 Refer to the RSA API Programming Reference Manual for details
 on any functions implemented from this module.
 """
+
 import logging
 import tempfile
 from ctypes import *

--- a/tests/test_rsa_api.py
+++ b/tests/test_rsa_api.py
@@ -2,6 +2,7 @@
 This is a test for the entire API Wrapper.
 It requires a compatible RSA device to be connected.
 """
+
 import unittest
 from os import environ, mkdir
 from os.path import isdir


### PR DESCRIPTION
Tested with Python 3.12 and added metadata to pyproject.toml.

Updated pre-commit hooks to latest versions and ran on all files.

Updated LICENSE.md and removed it from pre-commit excludes.