### PR TITLE
Update package metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
@@ -31,7 +31,7 @@ repos:
       - id: black
         types: [file, python]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
         types: [file, markdown]

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Microsoft and Windows are trademarks of the Microsoft group of companies.
 
 ## Contact
 
-For technical questions, contact Anthony Romaniello, <aromaniello@ntia.gov>
+For technical questions, contact [the ITS Spectrum Monitoring Team](mailto:spectrummonitoring@ntia.gov).
 
 ## Disclaimer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,6 @@ authors = [
     { name = "The Institute for Telecommunication Sciences" },
 ]
 
-maintainers = [
-    { name="Anthony Romaniello", email="aromaniello@ntia.gov"},
-]
-
 keywords = [
     "API", "wrapper", "spectrum", "analyzer", "SDR", "RF",
     "SCOS", "Linux", "Tektronix", "RSA", "radio",

--- a/src/rsa_api/__init__.py
+++ b/src/rsa_api/__init__.py
@@ -1,3 +1,3 @@
 from .rsa_api import *
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
- Removed "maintainer" metadata from `pyproject.toml`. On [PyPI](https://pypi.org/project/tekrsa-api-wrap), this removes the following from the sidebar: 
![image](https://github.com/user-attachments/assets/50ef3372-f1d8-41d0-8fd5-1126fe9408d9)
 however the PyPI owners/maintainers are still shown, e.g. 
![image](https://github.com/user-attachments/assets/9e1775a7-b4bf-4d72-9c29-c6355fe6cb69)

- Update contact info in README to use SpecMon team email address
- Update pre-commit hooks and bump package version to 2.0.1 so a new PyPI release can be made with the updated package metadata